### PR TITLE
Update project packages

### DIFF
--- a/Client/ADefWebserver.Module.HtmlTextV2.Client.csproj
+++ b/Client/ADefWebserver.Module.HtmlTextV2.Client.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.6" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Client/ADefWebserver.Module.HtmlTextV2.Client.csproj
+++ b/Client/ADefWebserver.Module.HtmlTextV2.Client.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.6" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.1.1" />

--- a/HtmlEditor.Blazor/HtmlEditor.Blazor.csproj
+++ b/HtmlEditor.Blazor/HtmlEditor.Blazor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<LibSassOutputStyle>expanded</LibSassOutputStyle>
 		<EnableDefaultSassItems>false</EnableDefaultSassItems>
 		<BaseIntermediateOutputPath />
@@ -16,15 +16,15 @@
 		<Description>Component isolated from Radzen</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibSassBuilder" Version="2.0.2" />
+    <PackageReference Include="LibSassBuilder" Version="3.0.0" />
 
-	<PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.25" />
+	<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.6" />
 
-	<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.8" />
+	<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.6 />
 
-	<PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.1.1" />
+	<PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.0" />
   </ItemGroup>
 
  
@@ -37,7 +37,7 @@
 
 
   <ItemGroup>
-    <Sass Include="$(MSBuildProjectDirectory)/themes/*.scss" Exclude="$(MSBuildProjectDirectory)/themes/_*.scss" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <Sass Include="$(MSBuildProjectDirectory)/themes/*.scss" Exclude="$(MSBuildProjectDirectory)/themes/_*.scss" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
 
@@ -64,7 +64,7 @@
 
 
 
- <Target Name="Sass" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' == 'net6.0'">
+ <Target Name="Sass" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' == 'net8.0'">
     <PropertyGroup>
       <_SassFileList>@(Sass->'"%(FullPath)"', ' ')</_SassFileList>
       <LibSassBuilderArgs>files $(_SassFileList) --outputstyle $(LibSassOutputStyle) --level $(LibSassOutputLevel)</LibSassBuilderArgs>
@@ -73,7 +73,7 @@
     <Message Text="Converted SassFile list to argument" Importance="$(LibSassMessageLevel)" />
   </Target>
 
-  <Target Name="MoveCss" AfterTargets="AfterCompile" Condition="'$(TargetFramework)' == 'net6.0'">
+  <Target Name="MoveCss" AfterTargets="AfterCompile" Condition="'$(TargetFramework)' == 'net8.0'">
     <ItemGroup>
         <CssFile Include="$(MSBuildProjectDirectory)/themes/*.css" />
     </ItemGroup>

--- a/Server/ADefWebserver.Module.HtmlTextV2.Server.csproj
+++ b/Server/ADefWebserver.Module.HtmlTextV2.Server.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Pull Request

This updates projects to latest package versions and also updates the HtmlEditor.Blazor project to .NET 8.0

Fixes #4 

### Additional Info
We should [update this line to 5.2.0 ](https://github.com/thabaum/ADefWebserver.Module.HtmlTextV2/blob/c6870e641747eab96cd615c1f190c1a58b872281/Package/ADefWebserver.Module.HtmlTextV2.nuspec#L19)once it is merged or use the branch I have with it updated already and to be recognized.... if it does anything!?

We should set this as our lowest allowed Oqtane version to match other package dependencies in the framework.


# 🚀 