### PR TITLE
Adds logic for "FocusAsync" from latest Radzen repository

### DIFF
--- a/HtmlEditor.Blazor/Common.cs
+++ b/HtmlEditor.Blazor/Common.cs
@@ -483,6 +483,13 @@ namespace HtmlEditor
         /// </summary>
         /// <value>The field identifier.</value>
         FieldIdentifier FieldIdentifier { get; }
+
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// Sets the focus.
+        /// </summary>
+        ValueTask FocusAsync();
+#endif
     }
 
 

--- a/HtmlEditor.Blazor/FormComponent.cs
+++ b/HtmlEditor.Blazor/FormComponent.cs
@@ -228,5 +228,13 @@ namespace HtmlEditor
         protected ClassList GetClassList(string className) => ClassList.Create(className)
                                                                        .AddDisabled(Disabled)
                                                                        .Add(FieldIdentifier, EditContext);
+
+#if NET5_0_OR_GREATER
+        /// <inheritdoc/>
+        public virtual async ValueTask FocusAsync()
+        {
+            await Element.FocusAsync();
+        }
+#endif
     }
 }

--- a/HtmlEditor.Blazor/HtmlEditorComponent.razor.cs
+++ b/HtmlEditor.Blazor/HtmlEditorComponent.razor.cs
@@ -116,23 +116,23 @@ namespace HtmlEditor.Blazor
         ElementReference ContentEditable { get; set; }
         HtmlEditorTextArea TextArea { get; set; }
 
-        //#if NET5_0_OR_GREATER
-        //        /// <summary>
-        //        /// Focuses the editor.
-        //        /// </summary>
-        //        public override ValueTask FocusAsync()
-        //        {
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// Focuses the editor.
+        /// </summary>
+        public override ValueTask FocusAsync()
+        {
 
-        //            if (mode == HtmlEditorMode.Design)
-        //            {
-        //                return ContentEditable.FocusAsync();
-        //            }
-        //            else
-        //            {
-        //                return TextArea.Element.FocusAsync();
-        //            }
-        //        }
-        //#endif
+            if (mode == HtmlEditorMode.Design)
+            {
+                return ContentEditable.FocusAsync();
+            }
+            else
+            {
+                return TextArea.Element.FocusAsync();
+            }
+        }
+#endif
 
         private readonly IDictionary<string, Func<Task>> shortcuts = new Dictionary<string, Func<Task>>();
 


### PR DESCRIPTION
This will add the FocusAsync task
```

#if NET5_0_OR_GREATER
        /// <summary>
        /// Sets the focus.
        /// </summary>
        ValueTask FocusAsync();
#endif
```

Maybe since we are running .NET 8 we don't need the `if endif` statement?

Merge and remove if desired.  This is how it is presented in the Radzen Html Editor repository files.  We can modify it as desired if it makes sense.

![image](https://github.com/ADefWebserver/ADefWebserver.Module.HtmlTextV2/assets/13577556/ecc4e628-d31e-4c53-9e95-25b94030ce35)
