### PR TITLE
Index.razor static rendering

### DIFF
--- a/Client/AssemblyInfo.cs
+++ b/Client/AssemblyInfo.cs
@@ -1,4 +1,3 @@
-using System.Resources;
 using Microsoft.Extensions.Localization;
 
 [assembly: RootNamespace("ADefWebserver.Module.HtmlTextV2.Client")]

--- a/Client/Interop.cs
+++ b/Client/Interop.cs
@@ -1,5 +1,4 @@
 using Microsoft.JSInterop;
-using System.Threading.Tasks;
 
 namespace ADefWebserver.Module.HtmlTextV2
 {

--- a/Client/Modules/ADefWebserver.Module.HtmlTextV2/Edit.razor
+++ b/Client/Modules/ADefWebserver.Module.HtmlTextV2/Edit.razor
@@ -52,8 +52,25 @@
 
 	public override List<Resource> Resources => new List<Resource>()
 	{
-		new Resource { ResourceType = ResourceType.Stylesheet, Url = "css/quill/quill.bubble.css" },
-		new Resource { ResourceType = ResourceType.Stylesheet, Url = "css/quill/quill.snow.css" }
+		new Resource { ResourceType = ResourceType.Script, Url = "_content/HtmlEditor.Blazor/HtmlEditor.Blazor.js" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = ModulePath() + "Module.css" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/css/default.css" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/MaterialIcons-Regular.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-300.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-700.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-regular.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Black.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-BlackIt.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Bold.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-BoldIt.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-ExtraLight.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-ExtraLightIt.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-It.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Light.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-LightIt.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Regular.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Semibold.woff" },
+		new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-SemiboldIt.woff" }
 	};
 
 	private RichTextEditor RichTextEditorHtml;

--- a/Client/Modules/ADefWebserver.Module.HtmlTextV2/Index.razor
+++ b/Client/Modules/ADefWebserver.Module.HtmlTextV2/Index.razor
@@ -11,66 +11,19 @@
     </div>
 }
 
+@((MarkupString)content)
+
 @if (PageState.EditMode && content.Length > 3000)
 {
     <div class="text-center mt-2">
         <ActionLink Action="Edit" EditMode="true" ResourceKey="Edit" />
     </div>
 }
-@if (EditorReady)
-{
-    <HtmlEditorDialog />
-    <HtmlEditorComponent @bind-Value=@content style="height: 500px; margin-bottom: 1rem;" UploadUrl="upload/image" Change=@OnChange Paste=@OnPaste Execute=@OnExecute />
-
-}
-else
-{
-    <div class="text-center">
-        <div class="spinner-border text-primary" role="status">
-            <span class="sr-only">Loading...</span>
-        </div>
-    </div>
-}
 
 @code {
-    bool EditorReady = false;
-    public override List<Resource> Resources => new List<Resource>()
-    {
-        new Resource { ResourceType = ResourceType.Script, Url = "_content/HtmlEditor.Blazor/HtmlEditor.Blazor.js" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = ModulePath() + "Module.css" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/css/default.css" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/MaterialIcons-Regular.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-300.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-700.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-regular.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Black.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-BlackIt.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Bold.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-BoldIt.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-ExtraLight.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-ExtraLightIt.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-It.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Light.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-LightIt.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Regular.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Semibold.woff" },
-        new Resource { ResourceType = ResourceType.Stylesheet, Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-SemiboldIt.woff" },
-    };
-
     private string content = "";
 
     public override string RenderMode => RenderModes.Static;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-
-        // Wait 1 second 
-        // to join the UI thread
-        await Task.Delay(1000);
-
-        EditorReady = true;
-    }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -95,39 +48,5 @@ else
             await logger.LogError(ex, "Error Loading Content {Error}", ex.Message);
             AddModuleMessage(Localizer["Error.Content.Load"], MessageType.Error);
         }
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        try
-        {
-            // register the JavaScript library declared in Resources
-            await base.OnAfterRenderAsync(firstRender);
-
-            if (!firstRender)
-            {
-               // EditorReady = true;
-            }
-        }
-        catch (Exception ex)
-        {
-            await logger.LogError(ex, "Error Loading Content {Error}", ex.Message);
-            AddModuleMessage(Localizer["Error.Content.Load"], MessageType.Error);
-        }
-    }
-
-    void OnPaste(HtmlEditorPasteEventArgs args)
-    {
-        //console.Log($"Paste: {args.Html}");
-    }
-
-    void OnChange(string html)
-    {
-        //console.Log($"Change: {html}");
-    }
-
-    void OnExecute(HtmlEditorExecuteEventArgs args)
-    {
-        //console.Log($"Execute: {args.CommandName}");
     }
 }

--- a/HtmlEditor.Blazor/HtmlEditorButtonBase.cs
+++ b/HtmlEditor.Blazor/HtmlEditorButtonBase.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace HtmlEditor.Blazor

--- a/HtmlEditor.Blazor/HtmlEditorColorBase.cs
+++ b/HtmlEditor.Blazor/HtmlEditorColorBase.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace HtmlEditor.Blazor

--- a/HtmlEditor.Blazor/Rendering/ClassList.cs
+++ b/HtmlEditor.Blazor/Rendering/ClassList.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Components.Forms;
 

--- a/HtmlEditor.Blazor/Rendering/EditorButton.razor
+++ b/HtmlEditor.Blazor/Rendering/EditorButton.razor
@@ -33,23 +33,6 @@
         await Click.InvokeAsync(null);
     }
 
-    // string Class
-    // {
-    //     get
-    //     {
-    //         var classList = new List<string>() { "html-editor-button-toolbar" };
-
-    //         if (Selected && !Editor.Disabled)
-    //         {
-    //             classList.Add("selected");
-    //         }
-
-    //         return string.Join(" ", classList);
-    //     }
-    // }
-
-
-
     string Class
     {
         get

--- a/HtmlEditor.Blazor/Rendering/HSV.cs
+++ b/HtmlEditor.Blazor/Rendering/HSV.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace HtmlEditor.Blazor.Rendering
 {
     /// <summary>

--- a/HtmlEditor.Blazor/Rendering/RGB.cs
+++ b/HtmlEditor.Blazor/Rendering/RGB.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 

--- a/HtmlEditor.Blazor/Rendering/TextMeasurer.cs
+++ b/HtmlEditor.Blazor/Rendering/TextMeasurer.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace HtmlEditor.Blazor.Rendering
 {
     /// <summary>

--- a/Server/Migrations/EntityBuilders/HtmlTextV2EntityBuilder.cs
+++ b/Server/Migrations/EntityBuilders/HtmlTextV2EntityBuilder.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
 using Oqtane.Databases.Interfaces;
 using Oqtane.Documentation;
-using Oqtane.Interfaces;
 using Oqtane.Migrations;
 using Oqtane.Migrations.EntityBuilders;
 

--- a/Shared/Modules/HtmlText/Models/HtmlText.cs
+++ b/Shared/Modules/HtmlText/Models/HtmlText.cs
@@ -1,7 +1,5 @@
-using System;
 using Oqtane.Models;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using Oqtane.Documentation;
 
 namespace ADefWebserver.Module.HtmlTextV2.Models


### PR DESCRIPTION
This sets the Index.razor component back to using default component.  Not sure if we want to or can use the `HtmlBase.razor` component instead.

Part 1 of fix #7 

Part 2 is a work in progress... if this gets merged wait for part 2 as it will not have any working POC to share until the `Edit.razor` component is merged.

This is a placeholder but can be merged if you are going to add the `Edit.razor` interactive component to the module.   I will attempt what I can.  We can worry about localization later.

This PR also cleans up a lot of namespaces that are not used in files in order to build using latest .NET 8.0.6

![image](https://github.com/ADefWebserver/ADefWebserver.Module.HtmlTextV2/assets/13577556/b990fd0b-d14c-4934-8233-5c89e023f248)
