### PR TITLE
Fix Release Build - Remove Files Not Found

### DIFF
--- a/Package/ADefWebserver.Module.HtmlTextV2.nuspec
+++ b/Package/ADefWebserver.Module.HtmlTextV2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata>
 		<id>ADefWebserver.Module.HtmlTextV2</id>
-		<version>1.1.0</version>
+		<version>2.0.0</version>
 		<authors>ADefWebserver</authors>
 		<owners>ADefWebserver</owners>
 		<title>HtmlTextV2</title>
@@ -16,7 +16,7 @@
 		<releaseNotes></releaseNotes>
 		<summary></summary>
 		<dependencies>
-			<dependency id="Oqtane.Framework" version="5.1.1" />
+			<dependency id="Oqtane.Framework" version="5.2.0" />
 		</dependencies>
 	</metadata>
 	<files>
@@ -28,8 +28,6 @@
 		<file src="..\Shared\bin\Release\net8.0\ADefWebserver.Module.HtmlTextV2.Shared.Oqtane.pdb" target="lib\net8.0" />
 		<file src="..\Client\bin\Release\net8.0\HtmlEditor.Blazor.dll" target="lib\net8.0" />
 		<file src="..\Client\bin\Release\net8.0\HtmlEditor.Blazor.pdb" target="lib\net8.0" />
-		<file src="..\Client\bin\Release\net8.0\System.Linq.Dynamic.Core" target="lib\net8.0" />
-		<file src="..\Client\bin\Release\net8.0\Microsoft.CSharp" target="lib\net8.0" />
 		<file src="..\Server\wwwroot\**\*.*" target="wwwroot" />
 		<file src="icon.png" target="" />
 	</files>


### PR DESCRIPTION

![image](https://github.com/ADefWebserver/ADefWebserver.Module.HtmlTextV2/assets/13577556/996bae40-d527-4291-ae9f-fcab0589da64)


This should make the release build work as it had two files it was trying to find I am not sure it needs.

If it does need them we need to figure out why they are not found after building.  I have not ran a release test yet, however this PR will allow it to build, we can re-add anything necessary later once issue found.  One package relates to .NET 5 and older... not sure it is relevant.