### PR TITLE
Remove file manager add dependencies

### DIFF
--- a/HtmlEditor.Blazor/HtmlEditor.Blazor.csproj
+++ b/HtmlEditor.Blazor/HtmlEditor.Blazor.csproj
@@ -56,6 +56,15 @@
     <SassFile Include="themes\_variables.scss" />
   </ItemGroup>
 
+	<ItemGroup>
+		<Reference Include="Oqtane.Shared">
+			<HintPath>..\..\oqtane.framework\Oqtane.Server\bin\Debug\net8.0\Oqtane.Shared.dll</HintPath>
+		</Reference>
+		<Reference Include="Oqtane.Client">
+			<HintPath>..\..\oqtane.framework\Oqtane.Server\bin\Debug\net8.0\Oqtane.Client.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+
   <Target Name="Sass" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' == 'net8.0'">
     <PropertyGroup>
       <_SassFileList>@(Sass->'"%(FullPath)"', ' ')</_SassFileList>

--- a/HtmlEditor.Blazor/HtmlEditorComponent.razor
+++ b/HtmlEditor.Blazor/HtmlEditorComponent.razor
@@ -44,7 +44,8 @@
                 <HtmlEditorUnlink />
                 @if (AllowFileManagement)
                 {
-                    <HtmlEditorImage />
+                   @*  **TODO**
+                   <HtmlEditorImage />*@
                 }
                 <HtmlEditorFontName />
                 <HtmlEditorFontSize />


### PR DESCRIPTION
This removes the `<HtmlEditorImage>` component from the toolbar of the HTML Editor by commenting it out for a later PR to introduce a working version if desired.

This PR also adds to the HtmlEditor.Blazor project file references to the `Oqtane.Client` and `Oqtane.Shared` dependencies.  This allows adding components like the File Manager and others to the components in the HtmlEditor.Blazor project.  This should help with a future image manager.