### PR TITLE
fixes #12 - removes Fonts declared as stylesheet resource types.

### DIFF
--- a/Client/Modules/ADefWebserver.Module.HtmlTextV2/ModuleInfo.cs
+++ b/Client/Modules/ADefWebserver.Module.HtmlTextV2/ModuleInfo.cs
@@ -23,55 +23,7 @@ namespace ADefWebserver.Module.HtmlTextV2
                 Url = "_content/HtmlEditor.Blazor/css/default.css" },
             new Resource {
                 ResourceType = ResourceType.Script,
-                Url = "_content/HtmlEditor.Blazor/HtmlEditor.Blazor.js" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/MaterialIcons-Regular.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-300.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-700.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/roboto-v15-latin-regular.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Black.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-BlackIt.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Bold.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-BoldIt.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-ExtraLight.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-ExtraLightIt.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-It.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Light.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-LightIt.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Regular.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-Semibold.woff" },
-            new Resource {
-                ResourceType = ResourceType.Stylesheet,
-                Url = "_content/HtmlEditor.Blazor/fonts/SourceSansPro-SemiboldIt.woff" },
+                Url = "_content/HtmlEditor.Blazor/HtmlEditor.Blazor.js" }
           }
         };
     }


### PR DESCRIPTION
fixes #12 - removes Fonts declared as stylesheet resource types.

![image](https://github.com/ADefWebserver/ADefWebserver.Module.HtmlTextV2/assets/13577556/32d89bba-62cf-4df3-b441-8b692cbc0ff2)

Errors loading fonts as stylesheets 100% resolved.